### PR TITLE
Fixed inclusion of `serde::{Deserialize, Serialize}` impls in docs.rs docs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # 0.3
 
+### 0.3.2
+
+Fixed inclusion of `serde::{Deserialize, Serialize}` impls in docs.rs docs
+
 ### 0.3.1
 
 Added optional `serde` dependency and `"serde"` feature to enable it

--- a/tstr/Cargo.toml
+++ b/tstr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tstr"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["rodrimati1992 <rodrimatt1985@gmail.com>"]
 edition = "2024"
 rust-version = "1.88.0"
@@ -65,7 +65,7 @@ version = "1.0"
 optional = true
 
 [package.metadata.docs.rs]
-features = ["docsrs", "const_panic", "nightly_str_generics"]
+features = ["docsrs", "const_panic", "serde", "nightly_str_generics"]
 
 
 

--- a/tstr/src/tstr_type.rs
+++ b/tstr/src/tstr_type.rs
@@ -155,6 +155,24 @@ use crate::{IsTStr, TStrArg, strlike::StrLike};
 ///
 /// `TStr` implements `serde::{Serialize, Deserialize}` when  the `"serde"` feature is enabled.
 ///
+#[cfg_attr(not(feature = "serde"), doc = "```ignore")]
+#[cfg_attr(feature = "serde", doc = "```rust")]
+/// use tstr::{TS, ts};
+///
+/// assert_eq!(serde_json::from_str::<TS!(foo)>(r#""foo""#).unwrap(), ts!(foo));
+///
+/// // trying to deserialize a `TS!(foo)` from any value other than `"foo"` produces an error
+/// assert!(serde_json::from_str::<TS!(foo)>(r#""bar""#).is_err());
+///
+///
+/// assert_eq!(serde_json::to_string(&ts!(wtf)).unwrap(), r#""wtf""#);
+///
+/// assert_eq!(serde_json::to_string(&ts!("hello")).unwrap(), r#""hello""#);
+///
+/// assert_eq!(serde_json::to_string(&ts!(12345)).unwrap(), r#""12345""#);
+///
+/// ```
+///
 ///
 pub struct TStr<S>(#[doc(hidden)] pub PhantomData<fn() -> S>);
 


### PR DESCRIPTION
Bumped version to 0.3.2

Updated changelog

Added doc example of de/serializing TStr